### PR TITLE
Integrate ShellCheck for shell script linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  shfmt:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -18,8 +18,11 @@ jobs:
       - name: Setup shfmt
         uses: mfinelli/setup-shfmt@v4
 
-      - name: Check formatting
+      - name: Check formatting (shfmt)
         run: shfmt -d -i 2 -ci -bn -sr scripts/ tests/
+
+      - name: Lint (shellcheck)
+        run: shellcheck --severity=warning scripts/*.sh scripts/lib/*.sh tests/*.sh
 
   validate:
     runs-on: ubuntu-latest

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,13 @@
+# Shell dialect
+shell=bash
+
+# Follow sourced files
+external-sources=true
+
+# Enable stricter checks
+enable=require-variable-braces
+enable=quote-safe-variables
+enable=check-unassigned-uppercase
+enable=check-extra-masked-returns
+enable=require-double-brackets
+enable=deprecate-which

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,17 +60,17 @@ Repository updates are also automated via GitHub Actions (trigger from Actions U
 
 See [docs/how-to/how-to-add-a-new-package.md](docs/how-to/how-to-add-a-new-package.md) for detailed steps.
 
-### Shell Script Formatting
+### Shell Script Quality
 
-Shell scripts are formatted with [shfmt](https://github.com/mvdan/sh). CI enforces formatting.
+Shell scripts are checked by [shfmt](https://github.com/mvdan/sh) (formatting) and
+[ShellCheck](https://github.com/koalaman/shellcheck) (linting). CI enforces both.
 
 ```bash
-# Check formatting (reports diff, exits non-zero if unformatted)
-shfmt -d -i 2 -ci -bn -sr scripts/ tests/
-
-# Auto-format all scripts
-shfmt -w -i 2 -ci -bn -sr scripts/ tests/
+make lint        # Check formatting (shfmt) + linting (shellcheck)
+make lint-fix    # Auto-fix formatting
 ```
+
+**shfmt flags:**
 
 | Flag   | Meaning                              |
 | ------ | ------------------------------------ |
@@ -78,6 +78,19 @@ shfmt -w -i 2 -ci -bn -sr scripts/ tests/
 | `-ci`  | Indent case labels                   |
 | `-bn`  | Binary ops (`&&`, `\|`) start a line |
 | `-sr`  | Redirect operators followed by space |
+
+**ShellCheck configuration (`.shellcheckrc`):**
+
+| Option                       | Meaning                                    |
+| ---------------------------- | ------------------------------------------ |
+| `shell=bash`                 | Assume bash dialect                        |
+| `external-sources=true`      | Follow sourced files                       |
+| `require-variable-braces`    | Require `${var}` instead of `$var`         |
+| `quote-safe-variables`       | Warn on unquoted variables                 |
+| `check-unassigned-uppercase` | Warn on uninitialized uppercase vars       |
+| `check-extra-masked-returns` | Detect hidden exit codes                   |
+| `require-double-brackets`    | Enforce `[[` over `[` for bash             |
+| `deprecate-which`            | Use `command -v` instead of `which`        |
 
 ### Build Landing Page (handled by Cloudflare)
 

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,10 @@ update: ## Update repo metadata (VERSIONS="pkg:1.0.0")
 sign: ## Sign Release file with GPG
 	./scripts/sign-release.sh
 
-lint: ## Check shell script formatting
+lint: ## Check shell scripts (formatting + linting)
 	shfmt -d -i 2 -ci -bn -sr scripts/ tests/
+	shellcheck --severity=warning scripts/*.sh scripts/lib/*.sh tests/*.sh
+	@echo "All checks passed"
 
 lint-fix: ## Fix shell script formatting
 	shfmt -w -i 2 -ci -bn -sr scripts/ tests/

--- a/scripts/lib/checksums.sh
+++ b/scripts/lib/checksums.sh
@@ -6,10 +6,10 @@
 get_file_size() {
   local file="$1"
   local result
-  if result=$(stat -c %s "$file" 2> /dev/null) && [[ "$result" =~ ^[0-9]+$ ]]; then
-    echo "$result"
-  elif result=$(stat -f %z "$file" 2> /dev/null) && [[ "$result" =~ ^[0-9]+$ ]]; then
-    echo "$result"
+  if result=$(stat -c %s "${file}" 2> /dev/null) && [[ "${result}" =~ ^[0-9]+$ ]]; then
+    echo "${result}"
+  elif result=$(stat -f %z "${file}" 2> /dev/null) && [[ "${result}" =~ ^[0-9]+$ ]]; then
+    echo "${result}"
   else
     return 1
   fi
@@ -20,10 +20,10 @@ get_file_size() {
 get_md5() {
   local file="$1"
   local result
-  if result=$(md5sum "$file" 2> /dev/null | cut -d' ' -f1) && [[ -n "$result" ]]; then
-    echo "$result"
-  elif result=$(md5 -q "$file" 2> /dev/null); then
-    echo "$result"
+  if result=$(md5sum "${file}" 2> /dev/null | cut -d' ' -f1) && [[ -n "${result}" ]]; then
+    echo "${result}"
+  elif result=$(md5 -q "${file}" 2> /dev/null); then
+    echo "${result}"
   else
     return 1
   fi
@@ -34,10 +34,10 @@ get_md5() {
 get_sha1() {
   local file="$1"
   local result
-  if result=$(sha1sum "$file" 2> /dev/null | cut -d' ' -f1) && [[ -n "$result" ]]; then
-    echo "$result"
-  elif result=$(shasum -a 1 "$file" 2> /dev/null | cut -d' ' -f1); then
-    echo "$result"
+  if result=$(sha1sum "${file}" 2> /dev/null | cut -d' ' -f1) && [[ -n "${result}" ]]; then
+    echo "${result}"
+  elif result=$(shasum -a 1 "${file}" 2> /dev/null | cut -d' ' -f1); then
+    echo "${result}"
   else
     return 1
   fi
@@ -48,10 +48,10 @@ get_sha1() {
 get_sha256() {
   local file="$1"
   local result
-  if result=$(sha256sum "$file" 2> /dev/null | cut -d' ' -f1) && [[ -n "$result" ]]; then
-    echo "$result"
-  elif result=$(shasum -a 256 "$file" 2> /dev/null | cut -d' ' -f1); then
-    echo "$result"
+  if result=$(sha256sum "${file}" 2> /dev/null | cut -d' ' -f1) && [[ -n "${result}" ]]; then
+    echo "${result}"
+  elif result=$(shasum -a 256 "${file}" 2> /dev/null | cut -d' ' -f1); then
+    echo "${result}"
   else
     return 1
   fi

--- a/scripts/lib/packages.sh
+++ b/scripts/lib/packages.sh
@@ -7,11 +7,11 @@
 get_package_version() {
   local pkg="$1"
   local packages_file="$2"
-  awk -v pkg="$pkg" '
+  awk -v pkg="${pkg}" '
         /^Package:/ { current_pkg = $2 }
         /^$/ { current_pkg = "" }
         /^Version:/ && current_pkg == pkg { print $2; exit }
-    ' "$packages_file"
+    ' "${packages_file}"
 }
 
 # Get entire stanza for a package from a Packages file
@@ -20,9 +20,9 @@ get_package_version() {
 get_package_block() {
   local pkg="$1"
   local packages_file="$2"
-  awk -v pkg="$pkg" '
+  awk -v pkg="${pkg}" '
         /^Package:/ { if ($2 == pkg) found=1; else found=0 }
         found { print }
         found && /^$/ { exit }
-    ' "$packages_file"
+    ' "${packages_file}"
 }

--- a/scripts/lib/require.sh
+++ b/scripts/lib/require.sh
@@ -16,8 +16,8 @@ require_bash4() {
 require_command() {
   local cmd="$1"
   local install_hint="${2:-}"
-  if ! command -v "$cmd" &> /dev/null; then
-    echo "Error: $cmd is required.${install_hint:+ $install_hint}" >&2
+  if ! command -v "${cmd}" &> /dev/null; then
+    echo "Error: ${cmd} is required.${install_hint:+ ${install_hint}}" >&2
     return 1
   fi
 }

--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -5,8 +5,8 @@
 # Usage: validate_package_name "package-name"
 validate_package_name() {
   local name="$1"
-  if [[ ! "$name" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
-    echo "Error: Invalid package name '$name'. Must be lowercase alphanumeric with hyphens." >&2
+  if [[ ! "${name}" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+    echo "Error: Invalid package name '${name}'. Must be lowercase alphanumeric with hyphens." >&2
     return 1
   fi
 }
@@ -15,8 +15,8 @@ validate_package_name() {
 # Usage: validate_version "1.0.0"
 validate_version() {
   local version="$1"
-  if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-    echo "Error: Invalid version '$version'. Must be semver format (e.g., 1.0.0 or 1.0.0-beta.1)." >&2
+  if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+    echo "Error: Invalid version '${version}'. Must be semver format (e.g., 1.0.0 or 1.0.0-beta.1)." >&2
     return 1
   fi
 }

--- a/scripts/sign-release.sh
+++ b/scripts/sign-release.sh
@@ -13,20 +13,20 @@ set -euo pipefail
 #       Passwordless keys are supported for local development.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-RELEASE_DIR="$REPO_ROOT/dists/stable"
+REPO_ROOT="$(dirname "${SCRIPT_DIR}")"
+RELEASE_DIR="${REPO_ROOT}/dists/stable"
 
-cd "$RELEASE_DIR"
+cd "${RELEASE_DIR}"
 
 if [[ ! -f Release ]]; then
-  echo "Error: Release file not found at $RELEASE_DIR/Release"
+  echo "Error: Release file not found at ${RELEASE_DIR}/Release"
   exit 1
 fi
 
 # Determine which GPG key to use
 KEY_ID="${GPG_KEY_ID:-}"
 
-if [[ -z "$KEY_ID" ]]; then
+if [[ -z "${KEY_ID}" ]]; then
   # Auto-select only if exactly one secret key exists
   mapfile -t KEY_IDS < <(gpg --list-secret-keys --keyid-format=long --with-colons 2> /dev/null | awk -F: '$1=="sec"{print $5}')
 
@@ -40,7 +40,7 @@ if [[ -z "$KEY_ID" ]]; then
   KEY_ID="${KEY_IDS[0]}"
 fi
 
-echo "Signing with key: $KEY_ID"
+echo "Signing with key: ${KEY_ID}"
 
 # Warn if no passphrase provided (may be intentional for passwordless keys)
 if [[ -z "${GPG_PASSPHRASE:-}" ]]; then
@@ -48,7 +48,7 @@ if [[ -z "${GPG_PASSPHRASE:-}" ]]; then
 fi
 
 # Create InRelease (clearsigned)
-gpg --default-key "$KEY_ID" \
+gpg --default-key "${KEY_ID}" \
   --batch --yes \
   --pinentry-mode loopback \
   --passphrase "${GPG_PASSPHRASE:-}" \
@@ -57,7 +57,7 @@ gpg --default-key "$KEY_ID" \
   Release
 
 # Create Release.gpg (detached signature)
-gpg --default-key "$KEY_ID" \
+gpg --default-key "${KEY_ID}" \
   --batch --yes \
   --pinentry-mode loopback \
   --passphrase "${GPG_PASSPHRASE:-}" \

--- a/scripts/update-repo.sh
+++ b/scripts/update-repo.sh
@@ -14,32 +14,32 @@ set -euo pipefail
 # packages are provided, only those get version updates; others retain their current versions.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-CONFIG_FILE="$REPO_ROOT/packages.yml"
-ARTIFACTS_DIR="$REPO_ROOT/artifacts"
+REPO_ROOT="$(dirname "${SCRIPT_DIR}")"
+CONFIG_FILE="${REPO_ROOT}/packages.yml"
+ARTIFACTS_DIR="${REPO_ROOT}/artifacts"
 
 # Load shared libraries
-source "$SCRIPT_DIR/lib/validation.sh"
-source "$SCRIPT_DIR/lib/checksums.sh"
-source "$SCRIPT_DIR/lib/require.sh"
-source "$SCRIPT_DIR/lib/packages.sh"
+source "${SCRIPT_DIR}/lib/validation.sh"
+source "${SCRIPT_DIR}/lib/checksums.sh"
+source "${SCRIPT_DIR}/lib/require.sh"
+source "${SCRIPT_DIR}/lib/packages.sh"
 
 # Parse command line arguments into associative array
 declare -A VERSIONS
 declare -a REQUESTED_PACKAGES=()
 for arg in "$@"; do
-  if [[ "$arg" == *:* ]]; then
+  if [[ "${arg}" == *:* ]]; then
     package="${arg%%:*}"
     version="${arg#*:}"
-    validate_package_name "$package" || exit 1
-    validate_version "$version" || exit 1
-    VERSIONS["$package"]="$version"
+    validate_package_name "${package}" || exit 1
+    validate_version "${version}" || exit 1
+    VERSIONS["${package}"]="${version}"
   else
-    package="$arg"
-    validate_package_name "$package" || exit 1
+    package="${arg}"
+    validate_package_name "${package}" || exit 1
     # Version will be fetched later
   fi
-  REQUESTED_PACKAGES+=("$package")
+  REQUESTED_PACKAGES+=("${package}")
 done
 
 # Check dependencies
@@ -54,19 +54,19 @@ require_dpkg || exit 1
 fetch_checksums_file() {
   local repo="$1"
   local version="$2"
-  local checksums_file="$ARTIFACTS_DIR/.checksums-${repo//\//-}-v${version}"
+  local checksums_file="${ARTIFACTS_DIR}/.checksums-${repo//\//-}-v${version}"
 
   # Return cached file if already downloaded
-  if [[ -f "$checksums_file" ]]; then
-    echo "$checksums_file"
+  if [[ -f "${checksums_file}" ]]; then
+    echo "${checksums_file}"
     return 0
   fi
 
   # Try common checksums file names
   local base_url="https://github.com/${repo}/releases/download/v${version}"
   for name in SHA256SUMS SHA256SUMS.txt checksums.txt checksums-sha256.txt; do
-    if curl -fsSL -o "$checksums_file" "${base_url}/${name}" 2> /dev/null; then
-      echo "$checksums_file"
+    if curl -fsSL -o "${checksums_file}" "${base_url}/${name}" 2> /dev/null; then
+      echo "${checksums_file}"
       return 0
     fi
   done
@@ -81,39 +81,39 @@ verify_checksum() {
   local file="$1"
   local checksums_file="$2"
   local filename
-  filename=$(basename "$file")
+  filename=$(basename "${file}")
 
   # Extract expected checksum for this file
   local expected
-  expected=$(awk -v f="$filename" '
+  expected=$(awk -v f="${filename}" '
         {
             # Handle both "hash  filename" and "hash *filename" formats
             gsub(/^\*/, "", $2)
             if ($2 == f) { print $1; exit }
         }
-    ' "$checksums_file")
+    ' "${checksums_file}")
 
-  if [[ -z "$expected" ]]; then
-    echo "Warning: No checksum found for $filename in checksums file"
+  if [[ -z "${expected}" ]]; then
+    echo "Warning: No checksum found for ${filename} in checksums file"
     return 1
   fi
 
   # Compute actual checksum
   local actual
-  if ! actual=$(get_sha256 "$file"); then
-    echo "Error: Failed to compute SHA256 for $file"
+  if ! actual=$(get_sha256 "${file}"); then
+    echo "Error: Failed to compute SHA256 for ${file}"
     return 1
   fi
 
   # Compare (exact match - SHA256 hashes are conventionally lowercase)
-  if [[ "$expected" != "$actual" ]]; then
-    echo "Error: Checksum mismatch for $filename"
-    echo "  Expected: $expected"
-    echo "  Actual:   $actual"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "Error: Checksum mismatch for ${filename}"
+    echo "  Expected: ${expected}"
+    echo "  Actual:   ${actual}"
     return 1
   fi
 
-  echo "Verified: $filename"
+  echo "Verified: ${filename}"
   return 0
 }
 
@@ -127,27 +127,27 @@ download_and_verify() {
 
   # Fetch checksums file first (required)
   local checksums_file
-  if ! checksums_file=$(fetch_checksums_file "$repo" "$version"); then
-    echo "Error: No SHA256SUMS file found for $repo v$version"
+  if ! checksums_file=$(fetch_checksums_file "${repo}" "${version}"); then
+    echo "Error: No SHA256SUMS file found for ${repo} v${version}"
     echo "Releases must include a checksums file (SHA256SUMS, SHA256SUMS.txt, checksums.txt, or checksums-sha256.txt)"
     exit 1
   fi
 
   local url="https://github.com/${repo}/releases/download/v${version}/${deb_file}"
-  echo "Downloading: $deb_file"
-  curl -fSL -o "$dest" "$url"
+  echo "Downloading: ${deb_file}"
+  curl -fSL -o "${dest}" "${url}"
 
   # Verify checksum
-  if ! verify_checksum "$dest" "$checksums_file"; then
-    echo "Error: Checksum verification failed for $deb_file"
-    rm -f "$dest"
+  if ! verify_checksum "${dest}" "${checksums_file}"; then
+    echo "Error: Checksum verification failed for ${deb_file}"
+    rm -f "${dest}"
     exit 1
   fi
 }
 
 # Read package list and architectures from config
-mapfile -t ALL_PACKAGES < <(yq -r '.packages[].name' "$CONFIG_FILE")
-mapfile -t ALL_ARCHS < <(yq -r '.packages[].architectures[]' "$CONFIG_FILE" | sort -u)
+mapfile -t ALL_PACKAGES < <(yq -r '.packages[].name' "${CONFIG_FILE}")
+mapfile -t ALL_ARCHS < <(yq -r '.packages[].architectures[]' "${CONFIG_FILE}" | sort -u)
 
 # Determine which packages to process
 # Note: We always regenerate metadata for ALL packages to keep the repository consistent.
@@ -159,16 +159,16 @@ else
 fi
 
 # Ensure artifacts directory is safe (no symlink path traversal)
-if [[ -L "$ARTIFACTS_DIR" ]]; then
-  echo "Error: $ARTIFACTS_DIR is a symlink, refusing to continue"
+if [[ -L "${ARTIFACTS_DIR}" ]]; then
+  echo "Error: ${ARTIFACTS_DIR} is a symlink, refusing to continue"
   exit 1
 fi
-mkdir -p "$ARTIFACTS_DIR"
+mkdir -p "${ARTIFACTS_DIR}"
 # Verify resolved path stays within repository
-REAL_ARTIFACTS="$(realpath "$ARTIFACTS_DIR")"
-REAL_REPO="$(realpath "$REPO_ROOT")"
-if [[ "$REAL_ARTIFACTS" != "$REAL_REPO/artifacts" ]]; then
-  echo "Error: Artifacts directory resolves outside repository: $REAL_ARTIFACTS"
+REAL_ARTIFACTS="$(realpath "${ARTIFACTS_DIR}")"
+REAL_REPO="$(realpath "${REPO_ROOT}")"
+if [[ "${REAL_ARTIFACTS}" != "${REAL_REPO}/artifacts" ]]; then
+  echo "Error: Artifacts directory resolves outside repository: ${REAL_ARTIFACTS}"
   exit 1
 fi
 
@@ -176,49 +176,49 @@ fi
 echo "==> Downloading packages..."
 for package in "${UPDATE_PACKAGES[@]}"; do
   # Validate package exists in config
-  if ! yq -e ".packages[] | select(.name == \"$package\")" "$CONFIG_FILE" &> /dev/null; then
-    echo "Error: Package '$package' not found in packages.yml"
+  if ! yq -e ".packages[] | select(.name == \"${package}\")" "${CONFIG_FILE}" &> /dev/null; then
+    echo "Error: Package '${package}' not found in packages.yml"
     exit 1
   fi
-  repo=$(yq -r ".packages[] | select(.name == \"$package\") | .repo" "$CONFIG_FILE")
-  mapfile -t archs < <(yq -r ".packages[] | select(.name == \"$package\") | .architectures[]" "$CONFIG_FILE")
+  repo=$(yq -r ".packages[] | select(.name == \"${package}\") | .repo" "${CONFIG_FILE}")
+  mapfile -t archs < <(yq -r ".packages[] | select(.name == \"${package}\") | .architectures[]" "${CONFIG_FILE}")
 
   # Get version from args or fetch latest
-  if [[ -v "VERSIONS[$package]" ]]; then
-    version="${VERSIONS[$package]}"
+  if [[ -v "VERSIONS[${package}]" ]]; then
+    version="${VERSIONS[${package}]}"
   else
-    echo "Fetching latest version for $package..."
-    version=$(gh release view --repo "$repo" --json tagName -q '.tagName' | sed 's/^v//')
+    echo "Fetching latest version for ${package}..."
+    version=$(gh release view --repo "${repo}" --json tagName -q '.tagName' | sed 's/^v//')
   fi
-  VERSIONS["$package"]="$version"
-  echo "Package $package: version $version"
+  VERSIONS["${package}"]="${version}"
+  echo "Package ${package}: version ${version}"
 
   for arch in "${archs[@]}"; do
     deb_file="${package}_${version}_${arch}.deb"
-    download_and_verify "$repo" "$version" "$deb_file" "$ARTIFACTS_DIR/$deb_file"
+    download_and_verify "${repo}" "${version}" "${deb_file}" "${ARTIFACTS_DIR}/${deb_file}"
   done
 done
 
 # For packages not being updated, fetch their current version from existing Packages file
 echo "==> Resolving versions for unchanged packages..."
 for package in "${ALL_PACKAGES[@]}"; do
-  if [[ ! -v "VERSIONS[$package]" ]]; then
+  if [[ ! -v "VERSIONS[${package}]" ]]; then
     # Try to get version from existing Packages files across all architectures
     existing_version=""
     for arch in "${ALL_ARCHS[@]}"; do
-      pkgs_file="$REPO_ROOT/dists/stable/main/binary-$arch/Packages"
-      if [[ -f "$pkgs_file" ]]; then
-        existing_version=$(get_package_version "$package" "$pkgs_file")
-        if [[ -n "$existing_version" ]]; then
+      pkgs_file="${REPO_ROOT}/dists/stable/main/binary-${arch}/Packages"
+      if [[ -f "${pkgs_file}" ]]; then
+        existing_version=$(get_package_version "${package}" "${pkgs_file}")
+        if [[ -n "${existing_version}" ]]; then
           break
         fi
       fi
     done
-    if [[ -n "$existing_version" ]]; then
-      VERSIONS["$package"]="$existing_version"
-      echo "Package $package: using existing version $existing_version"
+    if [[ -n "${existing_version}" ]]; then
+      VERSIONS["${package}"]="${existing_version}"
+      echo "Package ${package}: using existing version ${existing_version}"
     else
-      echo "Error: No version found for $package (not in args, not in existing metadata)"
+      echo "Error: No version found for ${package} (not in args, not in existing metadata)"
       exit 1
     fi
   fi
@@ -226,15 +226,15 @@ done
 
 # Download any missing packages (those with existing versions but no local .deb)
 for package in "${ALL_PACKAGES[@]}"; do
-  repo=$(yq -r ".packages[] | select(.name == \"$package\") | .repo" "$CONFIG_FILE")
-  mapfile -t archs < <(yq -r ".packages[] | select(.name == \"$package\") | .architectures[]" "$CONFIG_FILE")
-  version="${VERSIONS[$package]}"
+  repo=$(yq -r ".packages[] | select(.name == \"${package}\") | .repo" "${CONFIG_FILE}")
+  mapfile -t archs < <(yq -r ".packages[] | select(.name == \"${package}\") | .architectures[]" "${CONFIG_FILE}")
+  version="${VERSIONS[${package}]}"
 
   for arch in "${archs[@]}"; do
-    deb_file="$ARTIFACTS_DIR/${package}_${version}_${arch}.deb"
-    if [[ ! -f "$deb_file" ]]; then
+    deb_file="${ARTIFACTS_DIR}/${package}_${version}_${arch}.deb"
+    if [[ ! -f "${deb_file}" ]]; then
       echo "Downloading missing: ${package}_${version}_${arch}.deb"
-      download_and_verify "$repo" "$version" "${package}_${version}_${arch}.deb" "$deb_file"
+      download_and_verify "${repo}" "${version}" "${package}_${version}_${arch}.deb" "${deb_file}"
     fi
   done
 done
@@ -242,45 +242,45 @@ done
 # Generate Packages files for each architecture
 echo "==> Generating Packages files..."
 for arch in "${ALL_ARCHS[@]}"; do
-  packages_dir="$REPO_ROOT/dists/stable/main/binary-${arch}"
-  mkdir -p "$packages_dir"
-  packages_file="$packages_dir/Packages"
+  packages_dir="${REPO_ROOT}/dists/stable/main/binary-${arch}"
+  mkdir -p "${packages_dir}"
+  packages_file="${packages_dir}/Packages"
 
   # Clear existing Packages file
-  > "$packages_file"
+  : > "${packages_file}"
 
   for package in "${ALL_PACKAGES[@]}"; do
     # Check if this package supports this architecture
-    if ! yq -e ".packages[] | select(.name == \"$package\") | .architectures[] | select(. == \"$arch\")" "$CONFIG_FILE" &> /dev/null; then
+    if ! yq -e ".packages[] | select(.name == \"${package}\") | .architectures[] | select(. == \"${arch}\")" "${CONFIG_FILE}" &> /dev/null; then
       continue
     fi
 
-    version="${VERSIONS[$package]}"
-    deb_file="$ARTIFACTS_DIR/${package}_${version}_${arch}.deb"
+    version="${VERSIONS[${package}]}"
+    deb_file="${ARTIFACTS_DIR}/${package}_${version}_${arch}.deb"
 
-    if [[ ! -f "$deb_file" ]]; then
-      echo "Warning: $deb_file not found, skipping"
+    if [[ ! -f "${deb_file}" ]]; then
+      echo "Warning: ${deb_file} not found, skipping"
       continue
     fi
 
     # Extract control file
-    dpkg-deb -f "$deb_file" > "$ARTIFACTS_DIR/control"
+    dpkg-deb -f "${deb_file}" > "${ARTIFACTS_DIR}/control"
 
     # Calculate checksums
-    if ! size=$(get_file_size "$deb_file"); then
-      echo "Error: Failed to get file size for $deb_file"
+    if ! size=$(get_file_size "${deb_file}"); then
+      echo "Error: Failed to get file size for ${deb_file}"
       exit 1
     fi
-    if ! md5=$(get_md5 "$deb_file"); then
-      echo "Error: Failed to compute MD5 for $deb_file"
+    if ! md5=$(get_md5 "${deb_file}"); then
+      echo "Error: Failed to compute MD5 for ${deb_file}"
       exit 1
     fi
-    if ! sha1=$(get_sha1 "$deb_file"); then
-      echo "Error: Failed to compute SHA1 for $deb_file"
+    if ! sha1=$(get_sha1 "${deb_file}"); then
+      echo "Error: Failed to compute SHA1 for ${deb_file}"
       exit 1
     fi
-    if ! sha256=$(get_sha256 "$deb_file"); then
-      echo "Error: Failed to compute SHA256 for $deb_file"
+    if ! sha256=$(get_sha256 "${deb_file}"); then
+      echo "Error: Failed to compute SHA256 for ${deb_file}"
       exit 1
     fi
 
@@ -290,25 +290,25 @@ for arch in "${ALL_ARCHS[@]}"; do
 
     # Append to Packages file
     {
-      cat "$ARTIFACTS_DIR/control"
+      cat "${ARTIFACTS_DIR}/control"
       echo "Filename: pool/main/${first_letter}/${package}/${package}_${version}_${arch}.deb"
-      echo "Size: $size"
-      echo "MD5sum: $md5"
-      echo "SHA1: $sha1"
-      echo "SHA256: $sha256"
+      echo "Size: ${size}"
+      echo "MD5sum: ${md5}"
+      echo "SHA1: ${sha1}"
+      echo "SHA256: ${sha256}"
       echo ""
-    } >> "$packages_file"
+    } >> "${packages_file}"
 
-    echo "Added $package ($arch) to Packages"
+    echo "Added ${package} (${arch}) to Packages"
   done
 
   # Create compressed version
-  gzip -9 -c "$packages_file" > "$packages_file.gz"
+  gzip -9 -c "${packages_file}" > "${packages_file}.gz"
 done
 
 # Generate Release file
 echo "==> Generating Release file..."
-cd "$REPO_ROOT/dists/stable"
+cd "${REPO_ROOT}/dists/stable"
 
 {
   echo "Origin: Knight Owl"
@@ -320,24 +320,24 @@ cd "$REPO_ROOT/dists/stable"
   echo "Date: $(date -Ru)"
   echo "MD5Sum:"
   for f in main/binary-*/Packages main/binary-*/Packages.gz; do
-    [ -f "$f" ] || continue
-    size=$(get_file_size "$f")
-    md5=$(get_md5 "$f")
-    printf " %s %8d %s\n" "$md5" "$size" "$f"
+    [[ -f "${f}" ]] || continue
+    size=$(get_file_size "${f}")
+    md5=$(get_md5 "${f}")
+    printf " %s %8d %s\n" "${md5}" "${size}" "${f}"
   done
   echo "SHA1:"
   for f in main/binary-*/Packages main/binary-*/Packages.gz; do
-    [ -f "$f" ] || continue
-    size=$(get_file_size "$f")
-    sha1=$(get_sha1 "$f")
-    printf " %s %8d %s\n" "$sha1" "$size" "$f"
+    [[ -f "${f}" ]] || continue
+    size=$(get_file_size "${f}")
+    sha1=$(get_sha1 "${f}")
+    printf " %s %8d %s\n" "${sha1}" "${size}" "${f}"
   done
   echo "SHA256:"
   for f in main/binary-*/Packages main/binary-*/Packages.gz; do
-    [ -f "$f" ] || continue
-    size=$(get_file_size "$f")
-    sha256=$(get_sha256 "$f")
-    printf " %s %8d %s\n" "$sha256" "$size" "$f"
+    [[ -f "${f}" ]] || continue
+    size=$(get_file_size "${f}")
+    sha256=$(get_sha256 "${f}")
+    printf " %s %8d %s\n" "${sha256}" "${size}" "${f}"
   done
 } > Release
 
@@ -346,7 +346,7 @@ cat Release
 
 # Clean up (skip with KEEP_ARTIFACTS=1 for testing)
 if [[ "${KEEP_ARTIFACTS:-}" != "1" ]]; then
-  rm -rf "$ARTIFACTS_DIR"
+  rm -rf "${ARTIFACTS_DIR}"
 fi
 
 echo "==> Done! Remember to sign the Release file."

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -13,38 +13,38 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-CONFIG_FILE="$REPO_ROOT/packages.yml"
+REPO_ROOT="$(dirname "${SCRIPT_DIR}")"
+CONFIG_FILE="${REPO_ROOT}/packages.yml"
 IMAGE="${1:-debian:bookworm-slim}"
 
 # Load shared libraries
-source "$REPO_ROOT/scripts/lib/require.sh"
+source "${REPO_ROOT}/scripts/lib/require.sh"
 
 # Check dependencies
 require_bash4 || exit 1
 require_yq || exit 1
 
-mapfile -t PACKAGES < <(yq -r '.packages[].name' "$CONFIG_FILE")
+mapfile -t PACKAGES < <(yq -r '.packages[].name' "${CONFIG_FILE}")
 
-echo "Testing ${#PACKAGES[@]} package(s) on $IMAGE"
+echo "Testing ${#PACKAGES[@]} package(s) on ${IMAGE}"
 echo "==========================================="
 echo ""
 
 FAILED=()
 
 for package in "${PACKAGES[@]}"; do
-  echo ">>> Testing: $package"
-  if "$SCRIPT_DIR/test-package.sh" "$package" "$IMAGE"; then
-    echo ">>> PASSED: $package"
+  echo ">>> Testing: ${package}"
+  if "${SCRIPT_DIR}/test-package.sh" "${package}" "${IMAGE}"; then
+    echo ">>> PASSED: ${package}"
   else
-    echo ">>> FAILED: $package"
-    FAILED+=("$package")
+    echo ">>> FAILED: ${package}"
+    FAILED+=("${package}")
   fi
   echo ""
 done
 
 echo "==========================================="
-if [ ${#FAILED[@]} -eq 0 ]; then
+if [[ ${#FAILED[@]} -eq 0 ]]; then
   echo "All ${#PACKAGES[@]} package(s) passed"
   exit 0
 else

--- a/tests/test-local-repo.sh
+++ b/tests/test-local-repo.sh
@@ -23,25 +23,25 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-CONFIG_FILE="$REPO_ROOT/packages.yml"
+REPO_ROOT="$(dirname "${SCRIPT_DIR}")"
+CONFIG_FILE="${REPO_ROOT}/packages.yml"
 
 # Parse --clean flag
 CLEAN_AFTER=0
 ARGS=()
 for arg in "$@"; do
-  if [[ "$arg" == "--clean" ]]; then
+  if [[ "${arg}" == "--clean" ]]; then
     CLEAN_AFTER=1
   else
-    ARGS+=("$arg")
+    ARGS+=("${arg}")
   fi
 done
 set -- "${ARGS[@]}"
 
 # Load shared libraries
-source "$REPO_ROOT/scripts/lib/require.sh"
-source "$REPO_ROOT/scripts/lib/checksums.sh"
-source "$REPO_ROOT/scripts/lib/packages.sh"
+source "${REPO_ROOT}/scripts/lib/require.sh"
+source "${REPO_ROOT}/scripts/lib/checksums.sh"
+source "${REPO_ROOT}/scripts/lib/packages.sh"
 
 # Colors for output
 RED='\033[0;31m'
@@ -64,89 +64,89 @@ require_bash4 || exit 1
 require_yq || exit 1
 
 echo "=== Running update-repo.sh ==="
-KEEP_ARTIFACTS=1 "$REPO_ROOT/scripts/update-repo.sh" "$@"
+KEEP_ARTIFACTS=1 "${REPO_ROOT}/scripts/update-repo.sh" "$@"
 echo ""
 
 echo "=== Validating generated metadata ==="
 
 # Get architectures from config
-mapfile -t ARCHS < <(yq -r '.packages[].architectures[]' "$CONFIG_FILE" | sort -u)
+mapfile -t ARCHS < <(yq -r '.packages[].architectures[]' "${CONFIG_FILE}" | sort -u)
 
 # Validate Packages files
 echo ""
 echo "--- Packages files ---"
 for arch in "${ARCHS[@]}"; do
-  packages_file="$REPO_ROOT/dists/stable/main/binary-$arch/Packages"
+  packages_file="${REPO_ROOT}/dists/stable/main/binary-${arch}/Packages"
 
-  if [[ ! -f "$packages_file" ]]; then
-    fail "Missing: $packages_file"
+  if [[ ! -f "${packages_file}" ]]; then
+    fail "Missing: ${packages_file}"
     continue
   fi
-  pass "Exists: binary-$arch/Packages"
+  pass "Exists: binary-${arch}/Packages"
 
   # Check required fields for each package entry
   while IFS= read -r pkg_name; do
     # Extract package block
-    block=$(get_package_block "$pkg_name" "$packages_file")
+    block=$(get_package_block "${pkg_name}" "${packages_file}")
 
-    if [[ -z "$block" ]]; then
-      fail "Package $pkg_name not found in binary-$arch/Packages"
+    if [[ -z "${block}" ]]; then
+      fail "Package ${pkg_name} not found in binary-${arch}/Packages"
       continue
     fi
 
     # Check required fields
     for field in Package Version Architecture Filename Size MD5sum SHA1 SHA256; do
-      if echo "$block" | grep -q "^$field:"; then
+      if echo "${block}" | grep -q "^${field}:"; then
         : # Field exists
       else
-        fail "Package $pkg_name missing field: $field"
+        fail "Package ${pkg_name} missing field: ${field}"
       fi
     done
 
     # Validate Filename path format
-    filename=$(echo "$block" | grep "^Filename:" | cut -d' ' -f2)
-    if [[ "$filename" =~ ^pool/main/[a-z]/.+/.+\.deb$ ]]; then
-      pass "Package $pkg_name ($arch): valid Filename path"
+    filename=$(echo "${block}" | grep "^Filename:" | cut -d' ' -f2)
+    if [[ "${filename}" =~ ^pool/main/[a-z]/.+/.+\.deb$ ]]; then
+      pass "Package ${pkg_name} (${arch}): valid Filename path"
     else
-      fail "Package $pkg_name ($arch): invalid Filename path: $filename"
+      fail "Package ${pkg_name} (${arch}): invalid Filename path: ${filename}"
     fi
 
     # Validate checksum of actual .deb file
-    deb_file="$REPO_ROOT/artifacts/$(basename "$filename")"
-    if [[ -f "$deb_file" ]]; then
-      expected_sha256=$(echo "$block" | grep "^SHA256:" | cut -d' ' -f2)
-      actual_sha256=$(get_sha256 "$deb_file")
+    deb_file="${REPO_ROOT}/artifacts/$(basename "${filename}")"
+    if [[ -f "${deb_file}" ]]; then
+      expected_sha256=$(echo "${block}" | grep "^SHA256:" | cut -d' ' -f2)
+      actual_sha256=$(get_sha256 "${deb_file}")
 
-      if [[ "$expected_sha256" == "$actual_sha256" ]]; then
-        pass "Package $pkg_name ($arch): SHA256 checksum matches"
+      if [[ "${expected_sha256}" == "${actual_sha256}" ]]; then
+        pass "Package ${pkg_name} (${arch}): SHA256 checksum matches"
       else
-        fail "Package $pkg_name ($arch): SHA256 mismatch"
-        info "Expected: $expected_sha256"
-        info "Actual:   $actual_sha256"
+        fail "Package ${pkg_name} (${arch}): SHA256 mismatch"
+        info "Expected: ${expected_sha256}"
+        info "Actual:   ${actual_sha256}"
       fi
     else
-      warn "Package $pkg_name ($arch): .deb file not found for checksum validation (already cleaned up?)"
+      warn "Package ${pkg_name} (${arch}): .deb file not found for checksum validation (already cleaned up?)"
     fi
 
-  done < <(yq -r ".packages[] | select(.architectures[] == \"$arch\") | .name" "$CONFIG_FILE")
+  done < <(yq -r ".packages[] | select(.architectures[] == \"${arch}\") | .name" "${CONFIG_FILE}")
 done
 
 # Validate Release file
 echo ""
 echo "--- Release file ---"
-release_file="$REPO_ROOT/dists/stable/Release"
+release_file="${REPO_ROOT}/dists/stable/Release"
 
-if [[ ! -f "$release_file" ]]; then
+if [[ ! -f "${release_file}" ]]; then
   fail "Missing: Release file"
 else
   pass "Exists: Release"
 
   # Check required fields
   for field in Origin Label Suite Codename Architectures Components Date MD5Sum SHA1 SHA256; do
-    if grep -q "^$field:" "$release_file"; then
-      pass "Release has field: $field"
+    if grep -q "^${field}:" "${release_file}"; then
+      pass "Release has field: ${field}"
     else
-      fail "Release missing field: $field"
+      fail "Release missing field: ${field}"
     fi
   done
 
@@ -154,25 +154,25 @@ else
   echo ""
   echo "--- Release checksums ---"
   for arch in "${ARCHS[@]}"; do
-    packages_file="dists/stable/main/binary-$arch/Packages"
-    packages_path="$REPO_ROOT/$packages_file"
+    packages_file="dists/stable/main/binary-${arch}/Packages"
+    packages_path="${REPO_ROOT}/${packages_file}"
 
-    if [[ ! -f "$packages_path" ]]; then
+    if [[ ! -f "${packages_path}" ]]; then
       continue
     fi
 
     # Get expected SHA256 from Release (must be in SHA256 section, not MD5Sum or SHA1)
-    expected=$(awk '/^SHA256:/{found=1; next} found && /^ /{print}' "$release_file" | grep "main/binary-$arch/Packages$" | grep -v ".gz" | awk '{print $1}')
+    expected=$(awk '/^SHA256:/{found=1; next} found && /^ /{print}' "${release_file}" | grep "main/binary-${arch}/Packages$" | grep -v ".gz" | awk '{print $1}')
 
     # Calculate actual SHA256
-    actual=$(get_sha256 "$packages_path")
+    actual=$(get_sha256 "${packages_path}")
 
-    if [[ "$expected" == "$actual" ]]; then
-      pass "Release SHA256 for binary-$arch/Packages matches"
+    if [[ "${expected}" == "${actual}" ]]; then
+      pass "Release SHA256 for binary-${arch}/Packages matches"
     else
-      fail "Release SHA256 for binary-$arch/Packages mismatch"
-      info "Expected: $expected"
-      info "Actual:   $actual"
+      fail "Release SHA256 for binary-${arch}/Packages mismatch"
+      info "Expected: ${expected}"
+      info "Actual:   ${actual}"
     fi
   done
 fi
@@ -181,42 +181,42 @@ fi
 echo ""
 echo "--- Compressed files ---"
 for arch in "${ARCHS[@]}"; do
-  packages_gz="$REPO_ROOT/dists/stable/main/binary-$arch/Packages.gz"
-  packages_file="$REPO_ROOT/dists/stable/main/binary-$arch/Packages"
+  packages_gz="${REPO_ROOT}/dists/stable/main/binary-${arch}/Packages.gz"
+  packages_file="${REPO_ROOT}/dists/stable/main/binary-${arch}/Packages"
 
-  if [[ ! -f "$packages_gz" ]]; then
-    fail "Missing: binary-$arch/Packages.gz"
+  if [[ ! -f "${packages_gz}" ]]; then
+    fail "Missing: binary-${arch}/Packages.gz"
     continue
   fi
-  pass "Exists: binary-$arch/Packages.gz"
+  pass "Exists: binary-${arch}/Packages.gz"
 
   # Verify gzip decompresses to same content
-  if diff -q <(gzip -dc "$packages_gz") "$packages_file" &> /dev/null; then
-    pass "binary-$arch/Packages.gz decompresses correctly"
+  if diff -q <(gzip -dc "${packages_gz}") "${packages_file}" &> /dev/null; then
+    pass "binary-${arch}/Packages.gz decompresses correctly"
   else
-    fail "binary-$arch/Packages.gz content mismatch"
+    fail "binary-${arch}/Packages.gz content mismatch"
   fi
 done
 
 # Clean up artifacts
-rm -rf "$REPO_ROOT/artifacts"
+rm -rf "${REPO_ROOT}/artifacts"
 
 echo ""
 echo "=== Summary ==="
-if [[ $FAILED -eq 0 ]]; then
+if [[ ${FAILED} -eq 0 ]]; then
   echo -e "${GREEN}All validations passed!${NC}"
   echo ""
   echo "Generated files:"
   echo "  - dists/stable/Release"
   for arch in "${ARCHS[@]}"; do
-    echo "  - dists/stable/main/binary-$arch/Packages"
-    echo "  - dists/stable/main/binary-$arch/Packages.gz"
+    echo "  - dists/stable/main/binary-${arch}/Packages"
+    echo "  - dists/stable/main/binary-${arch}/Packages.gz"
   done
   echo ""
-  if [[ $CLEAN_AFTER -eq 1 ]]; then
+  if [[ ${CLEAN_AFTER} -eq 1 ]]; then
     read -rp "Restore dists/ to discard changes? [y/N] " response
-    if [[ "$response" =~ ^[Yy]$ ]]; then
-      git -C "$REPO_ROOT" restore dists/
+    if [[ "${response}" =~ ^[Yy]$ ]]; then
+      git -C "${REPO_ROOT}" restore dists/
       echo "Restored dists/"
     fi
   else

--- a/tests/test-package.sh
+++ b/tests/test-package.sh
@@ -19,46 +19,46 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-CONFIG_FILE="$REPO_ROOT/packages.yml"
+REPO_ROOT="$(dirname "${SCRIPT_DIR}")"
+CONFIG_FILE="${REPO_ROOT}/packages.yml"
 
 # Load shared libraries
-source "$REPO_ROOT/scripts/lib/validation.sh"
-source "$REPO_ROOT/scripts/lib/require.sh"
+source "${REPO_ROOT}/scripts/lib/validation.sh"
+source "${REPO_ROOT}/scripts/lib/require.sh"
 
 # Check dependencies
 require_yq || exit 1
 require_docker || exit 1
 
 # Get package name (default to first package in config)
-PACKAGE="${1:-$(yq -r '.packages[0].name' "$CONFIG_FILE")}"
+PACKAGE="${1:-$(yq -r '.packages[0].name' "${CONFIG_FILE}")}"
 IMAGE="${2:-debian:bookworm-slim}"
 
 # Validate package name format (if user-provided)
 if [[ -n "${1:-}" ]]; then
-  validate_package_name "$PACKAGE" || exit 1
+  validate_package_name "${PACKAGE}" || exit 1
 fi
 
 # Validate package exists in config
-if ! yq -e ".packages[] | select(.name == \"$PACKAGE\")" "$CONFIG_FILE" &> /dev/null; then
-  echo "Error: Package '$PACKAGE' not found in packages.yml"
+if ! yq -e ".packages[] | select(.name == \"${PACKAGE}\")" "${CONFIG_FILE}" &> /dev/null; then
+  echo "Error: Package '${PACKAGE}' not found in packages.yml"
   echo "Available packages:"
-  yq -r '.packages[].name' "$CONFIG_FILE" | sed 's/^/  - /'
+  yq -r '.packages[].name' "${CONFIG_FILE}" | sed 's/^/  - /'
   exit 1
 fi
 
 # Get verify command (optional)
-VERIFY_CMD=$(yq -r ".packages[] | select(.name == \"$PACKAGE\") | .verify // \"\"" "$CONFIG_FILE")
+VERIFY_CMD=$(yq -r ".packages[] | select(.name == \"${PACKAGE}\") | .verify // \"\"" "${CONFIG_FILE}")
 
-echo "Testing package: $PACKAGE"
-echo "Image: $IMAGE"
+echo "Testing package: ${PACKAGE}"
+echo "Image: ${IMAGE}"
 echo "Verify command: ${VERIFY_CMD:-<none>}"
 echo "==========================================="
 
 docker run --rm \
-  -e "PACKAGE=$PACKAGE" \
-  -e "VERIFY_CMD=$VERIFY_CMD" \
-  "$IMAGE" bash -c '
+  -e "PACKAGE=${PACKAGE}" \
+  -e "VERIFY_CMD=${VERIFY_CMD}" \
+  "${IMAGE}" bash -c '
 set -e
 
 echo "=== Adding Knight Owl apt repository ==="


### PR DESCRIPTION
## Summary

- Add `.shellcheckrc` with stricter checks enabled
- Add ShellCheck to CI `lint` job alongside shfmt
- Combine `make lint` to run both shfmt and shellcheck
- Fix all ShellCheck warnings (variable braces, double brackets)
- Document configuration in CLAUDE.md

Closes #13

## Test plan

- [x] `make lint` passes with "All checks passed" message
- [x] `make validate` passes

🤖 Generated with [Claude Code](https://claude.ai/code)