### PR TITLE
Add Biome linting for JavaScript files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,23 @@ jobs:
       - name: Setup shfmt
         uses: mfinelli/setup-shfmt@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Check formatting (shfmt)
         run: shfmt -d -i 2 -ci -bn -sr scripts/ tests/
 
-      - name: Lint (shellcheck)
+      - name: Lint shell (shellcheck)
         run: shellcheck --severity=warning scripts/*.sh scripts/lib/*.sh tests/*.sh
+
+      - name: Lint JS (biome)
+        run: npx biome check functions/
 
   validate:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,13 @@ This design minimizes storage since only apt metadata is stored here, while bina
 ## Repository Structure
 
 ```plain
+biome.json                               # Biome (JS linter) configuration
 dists/stable/                            # Release files (Release, InRelease, Release.gpg)
 dists/stable/main/binary-{amd64,arm64}/  # Apt package metadata (Packages, Packages.gz)
 docs/how-to/                             # Documentation guides
 functions/_middleware.js                 # Access control (blocks dev files from public)
 functions/pool/main/<letter>/<package>/  # Cloudflare Functions for binary redirects
+package.json                             # Node.js dependencies (Biome)
 packages.yml                             # Package configuration (add new packages here)
 scripts/create-update-pr.sh              # Create PRs for repository updates
 scripts/lib/                             # Shared shell libraries (validation, checksums, require)
@@ -35,8 +37,8 @@ Run `make help` to see all available commands. Examples:
 ```bash
 make clean                               # Remove generated artifacts
 make help                                # Show available commands
-make lint                                # Check shell scripts (formatting + linting)
-make lint-fix                            # Fix shell script formatting
+make lint                                # Check all (shell + JS)
+make lint-fix                            # Fix all formatting
 make sign                                # Sign Release file with GPG
 make test                                # Test all packages
 make test IMAGE=ubuntu:24.04             # Test on specific image
@@ -67,15 +69,21 @@ Repository updates are also automated via GitHub Actions (trigger from Actions U
 
 See [docs/how-to/how-to-add-a-new-package.md](docs/how-to/how-to-add-a-new-package.md) for detailed steps.
 
-### Shell Script Quality
+### Code Quality
 
-Shell scripts are checked by [shfmt](https://github.com/mvdan/sh) (formatting) and
-[ShellCheck](https://github.com/koalaman/shellcheck) (linting). CI enforces both.
+Shell scripts and JavaScript are linted in CI.
 
 ```bash
-make lint        # Check formatting (shfmt) + linting (shellcheck)
-make lint-fix    # Auto-fix formatting
+make lint          # Check all (shell + JS)
+make lint-fix      # Fix all formatting
+make lint-sh       # Check shell only
+make lint-js       # Check JS only
 ```
+
+#### Shell (shfmt + ShellCheck)
+
+Shell scripts are checked by [shfmt](https://github.com/mvdan/sh) (formatting) and
+[ShellCheck](https://github.com/koalaman/shellcheck) (linting).
 
 **shfmt flags:**
 
@@ -99,6 +107,18 @@ make lint-fix    # Auto-fix formatting
 | `require-double-brackets`    | Enforce `[[` over `[` for bash             |
 | `deprecate-which`            | Use `command -v` instead of `which`        |
 
+#### JavaScript (Biome)
+
+Cloudflare Functions are checked by [Biome](https://biomejs.dev/) for linting and formatting.
+
+**Biome configuration (`biome.json`):**
+
+| Option                            | Value    | Meaning                    |
+| --------------------------------- | -------- | -------------------------- |
+| `formatter.indentStyle`           | `space`  | Use spaces for indentation |
+| `formatter.indentWidth`           | `2`      | 2-space indentation        |
+| `javascript.formatter.quoteStyle` | `single` | Use single quotes          |
+
 ### Workflow Script Style
 
 Inline shell scripts in GitHub Actions workflows can't be auto-linted. Follow these guidelines:
@@ -113,6 +133,11 @@ Inline shell scripts in GitHub Actions workflows can't be auto-linted. Follow th
 ```bash
 npx markdown-to-html-cli --source README.md --output index.html
 ```
+
+### Commit Messages
+
+- Do not reference issues in commit message titles or bodies unless explicitly requested
+- Issue linking is managed through PRs, not commit messages
 
 ## Architecture Details
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test validate update sign lint lint-fix clean
+.PHONY: help test validate update sign lint lint-sh lint-js lint-fix lint-sh-fix lint-js-fix clean
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-12s %s\n", $$1, $$2}'
@@ -23,13 +23,23 @@ update: ## Update repo metadata (VERSIONS="pkg:1.0.0")
 sign: ## Sign Release file with GPG
 	./scripts/sign-release.sh
 
-lint: ## Check shell scripts (formatting + linting)
-	shfmt -d -i 2 -ci -bn -sr scripts/ tests/
-	shellcheck --severity=warning scripts/*.sh scripts/lib/*.sh tests/*.sh
+lint: lint-sh lint-js ## Check all (shell + JS)
 	@echo "All checks passed"
 
-lint-fix: ## Fix shell script formatting
+lint-sh: ## Check shell scripts (formatting + linting)
+	shfmt -d -i 2 -ci -bn -sr scripts/ tests/
+	shellcheck --severity=warning scripts/*.sh scripts/lib/*.sh tests/*.sh
+
+lint-js: ## Check JavaScript (biome)
+	npx biome check functions/
+
+lint-fix: lint-sh-fix lint-js-fix ## Fix all formatting
+
+lint-sh-fix: ## Fix shell script formatting
 	shfmt -w -i 2 -ci -bn -sr scripts/ tests/
+
+lint-js-fix: ## Fix JavaScript formatting
+	npx biome check --write functions/
 
 clean: ## Remove generated artifacts
 	rm -rf artifacts/

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "files": {
+    "include": ["functions/**/*.js"]
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  }
+}

--- a/docs/how-to/how-to-add-a-new-package.md
+++ b/docs/how-to/how-to-add-a-new-package.md
@@ -70,7 +70,9 @@ export function onRequest(context) {
 
   // Update the regex to match your package name
   // Version must be semver: X.Y.Z or X.Y.Z-prerelease (e.g., 1.0.0, 2.1.0-beta.1)
-  const match = filename.match(/^my-new-package_(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?)_(amd64|arm64)\.deb$/);
+  const match = filename.match(
+    /^my-new-package_(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?)_(amd64|arm64)\.deb$/,
+  );
 
   if (!match) {
     return new Response('Not found', { status: 404 });

--- a/functions/pool/main/k/keystone-cli/[[path]].js
+++ b/functions/pool/main/k/keystone-cli/[[path]].js
@@ -17,7 +17,9 @@ export function onRequest(context) {
 
   // Parse version from filename: keystone-cli_{version}_{arch}.deb
   // Version must be semver format: X.Y.Z or X.Y.Z-prerelease (e.g., 0.1.9, 1.0.0-beta.1)
-  const match = filename.match(/^keystone-cli_(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?)_(amd64|arm64)\.deb$/);
+  const match = filename.match(
+    /^keystone-cli_(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?)_(amd64|arm64)\.deb$/,
+  );
 
   if (!match) {
     return new Response('Not found', { status: 404 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,176 @@
+{
+  "name": "apt",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@biomejs/biome": "^1.9.4"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.9.4",
+        "@biomejs/cli-darwin-x64": "1.9.4",
+        "@biomejs/cli-linux-arm64": "1.9.4",
+        "@biomejs/cli-linux-arm64-musl": "1.9.4",
+        "@biomejs/cli-linux-x64": "1.9.4",
+        "@biomejs/cli-linux-x64-musl": "1.9.4",
+        "@biomejs/cli-win32-arm64": "1.9.4",
+        "@biomejs/cli-win32-x64": "1.9.4"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4"
+  }
+}


### PR DESCRIPTION
## Summary

- Add Biome for JavaScript linting and formatting
- Refactor Makefile with composite lint targets (`lint-sh`, `lint-js`)
- Update CI to single lint job with shell + JS checks
- Use `node-version: lts/*` for automatic Node.js LTS updates
- Add npm ecosystem to Dependabot for automatic Biome updates
- Update documentation (CLAUDE.md, how-to guide)

## Test plan

- [x] `make lint` passes (shell + JS)
- [x] `make lint-fix` works
- [x] CI workflow runs successfully

Closes #18

🤖 Generated with [Claude Code](https://claude.ai/claude-code)