### PR TITLE
Refactor test scripts for consistency and lintability

### DIFF
--- a/tests/docker-install.sh
+++ b/tests/docker-install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#
+# Install and verify an apt package inside a Docker container.
+#
+# This script is mounted into a Docker container by test-package.sh.
+# It should not be run directly on the host.
+#
+# Environment variables (set by test-package.sh):
+#   PACKAGE    - Package name to install
+#   VERIFY_CMD - Optional command to verify the package works
+#
+
+# Required environment variables
+: "${PACKAGE:?PACKAGE must be set}"
+: "${VERIFY_CMD=}" # Optional, default to empty
+
+echo "=== Adding Knight Owl apt repository ==="
+apt-get update
+apt-get install -y curl gnupg ca-certificates
+
+echo ""
+echo "=== Importing GPG key ==="
+curl -fsSL https://apt.knight-owl.dev/PUBLIC.KEY | gpg --dearmor -o /usr/share/keyrings/knight-owl.gpg
+gpg --no-default-keyring --keyring /usr/share/keyrings/knight-owl.gpg --list-keys
+
+echo ""
+echo "=== Adding repository ==="
+echo "deb [signed-by=/usr/share/keyrings/knight-owl.gpg] https://apt.knight-owl.dev stable main" > /etc/apt/sources.list.d/knight-owl.list
+cat /etc/apt/sources.list.d/knight-owl.list
+
+echo ""
+echo "=== Updating package lists ==="
+apt-get update
+
+echo ""
+echo "=== Installing ${PACKAGE} ==="
+apt-get install -y "${PACKAGE}"
+
+echo ""
+echo "=== Verifying installation ==="
+dpkg -s "${PACKAGE}" | grep -E "^(Package|Version|Status):"
+
+if [[ -n "${VERIFY_CMD}" ]]; then
+  echo ""
+  echo "=== Running verify command (as non-root user) ==="
+  # Create non-root user to run verify command (more realistic)
+  useradd -m testuser
+  # Run via bash -c to properly handle quoted arguments with spaces
+  runuser -u testuser -- bash -c "${VERIFY_CMD}"
+fi
+
+echo ""
+echo "==========================================="
+echo "SUCCESS: ${PACKAGE} installed and working"
+echo "==========================================="

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Test all packages from packages.yml
 #
@@ -9,8 +11,6 @@
 #   ./tests/test-all.sh                    # Test all packages on debian:bookworm-slim
 #   ./tests/test-all.sh ubuntu:24.04       # Test all packages on Ubuntu 24.04
 #
-
-set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "${SCRIPT_DIR}")"

--- a/tests/test-local-repo.sh
+++ b/tests/test-local-repo.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Test the update-repo.sh script locally and validate generated metadata.
 #
@@ -19,8 +21,6 @@
 #   3. Validates Release file has correct checksums
 #   4. Validates .deb files match their checksums
 #
-
-set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "${SCRIPT_DIR}")"

--- a/tests/test-package.sh
+++ b/tests/test-package.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 #
 # Test apt package installation in a Docker container.
 #
@@ -15,8 +17,6 @@
 #   - yq must be installed (brew install yq)
 #   - The apt repository must be live at apt.knight-owl.dev
 #
-
-set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "${SCRIPT_DIR}")"
@@ -58,46 +58,5 @@ echo "==========================================="
 docker run --rm \
   -e "PACKAGE=${PACKAGE}" \
   -e "VERIFY_CMD=${VERIFY_CMD}" \
-  "${IMAGE}" bash -c '
-set -e
-
-echo "=== Adding Knight Owl apt repository ==="
-apt-get update
-apt-get install -y curl gnupg ca-certificates
-
-echo ""
-echo "=== Importing GPG key ==="
-curl -fsSL https://apt.knight-owl.dev/PUBLIC.KEY | gpg --dearmor -o /usr/share/keyrings/knight-owl.gpg
-gpg --no-default-keyring --keyring /usr/share/keyrings/knight-owl.gpg --list-keys
-
-echo ""
-echo "=== Adding repository ==="
-echo "deb [signed-by=/usr/share/keyrings/knight-owl.gpg] https://apt.knight-owl.dev stable main" > /etc/apt/sources.list.d/knight-owl.list
-cat /etc/apt/sources.list.d/knight-owl.list
-
-echo ""
-echo "=== Updating package lists ==="
-apt-get update
-
-echo ""
-echo "=== Installing $PACKAGE ==="
-apt-get install -y "$PACKAGE"
-
-echo ""
-echo "=== Verifying installation ==="
-dpkg -s "$PACKAGE" | grep -E "^(Package|Version|Status):"
-
-if [ -n "$VERIFY_CMD" ]; then
-    echo ""
-    echo "=== Running verify command (as non-root user) ==="
-    # Create non-root user to run verify command (more realistic)
-    useradd -m testuser
-    # Run via bash -c to properly handle quoted arguments with spaces
-    runuser -u testuser -- bash -c "$VERIFY_CMD"
-fi
-
-echo ""
-echo "==========================================="
-echo "SUCCESS: $PACKAGE installed and working"
-echo "==========================================="
-'
+  -v "${SCRIPT_DIR}/docker-install.sh:/install.sh:ro" \
+  "${IMAGE}" bash /install.sh


### PR DESCRIPTION
## Summary

- Move `set -euo pipefail` immediately after shebang in all test scripts, matching the convention in `scripts/`
- Extract inline Docker script from `test-package.sh` to `tests/docker-install.sh` so it can be linted
- Apply linting fixes: `[[ ]]` instead of `[ ]`, `${VAR}` instead of `$VAR`, 2-space indentation

## Test plan

- [x] `make lint-sh` passes
- [x] `./tests/test-package.sh` passes

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)