### PR TITLE
Add actionlint for GitHub Actions workflow linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Lint JS (biome)
         run: npx biome check functions/
 
+      - name: Setup actionlint
+        uses: raven-actions/actionlint@v2
+
+      - name: Check GitHub Actions workflows (actionlint)
+        run: actionlint
+
   validate:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -56,7 +56,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSIONS: ${{ steps.args.outputs.versions }}
         run: |
-          # shellcheck disable=SC2086 -- $VERSIONS must word-split to pass multiple package specs as separate args
+          # shellcheck disable=SC2086
+          # $VERSIONS must word-split to pass multiple package specs as separate args
           ./scripts/update-repo.sh ${VERSIONS}
 
       - name: Import GPG key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,10 +71,10 @@ See [docs/how-to/how-to-add-a-new-package.md](docs/how-to/how-to-add-a-new-packa
 
 ### Code Quality
 
-Shell scripts and JavaScript are linted in CI.
+Shell scripts, JavaScript, and GitHub Actions workflows are linted in CI.
 
 ```bash
-make lint          # Check all (shell + JS)
+make lint          # Check all (shell + JS + actions)
 make lint-fix      # Fix all formatting
 make lint-sh       # Check shell only
 make lint-js       # Check JS only
@@ -118,6 +118,22 @@ Cloudflare Functions are checked by [Biome](https://biomejs.dev/) for linting an
 | `formatter.indentStyle`           | `space`  | Use spaces for indentation |
 | `formatter.indentWidth`           | `2`      | 2-space indentation        |
 | `javascript.formatter.quoteStyle` | `single` | Use single quotes          |
+
+#### GitHub Actions (actionlint)
+
+GitHub Actions workflows are checked by [actionlint](https://github.com/rhysd/actionlint).
+
+```bash
+make lint-actions  # Check workflows only (requires actionlint installed locally)
+```
+
+actionlint validates:
+
+- Workflow syntax and structure
+- Action and reusable workflow references
+- Expression syntax (`${{ }}`)
+- Shell script syntax in `run:` steps
+- Runner labels and matrix configurations
 
 ### Workflow Script Style
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test validate update sign lint lint-sh lint-js lint-fix lint-sh-fix lint-js-fix clean
+.PHONY: help test validate update sign lint lint-sh lint-js lint-actions lint-fix lint-sh-fix lint-js-fix clean
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-12s %s\n", $$1, $$2}'
@@ -23,7 +23,7 @@ update: ## Update repo metadata (VERSIONS="pkg:1.0.0")
 sign: ## Sign Release file with GPG
 	./scripts/sign-release.sh
 
-lint: lint-sh lint-js ## Check all (shell + JS)
+lint: lint-sh lint-js lint-actions ## Check all (shell + JS + actions)
 	@echo "All checks passed"
 
 lint-sh: ## Check shell scripts (formatting + linting)
@@ -32,6 +32,9 @@ lint-sh: ## Check shell scripts (formatting + linting)
 
 lint-js: ## Check JavaScript (biome)
 	npx biome check functions/
+
+lint-actions: ## Check GitHub Actions workflows (actionlint)
+	actionlint
 
 lint-fix: lint-sh-fix lint-js-fix ## Fix all formatting
 


### PR DESCRIPTION
## Summary

- Add actionlint to CI workflow to lint GitHub Actions workflows
- Add `make lint-actions` target for local workflow linting
- Update documentation in CLAUDE.md with actionlint details
- Fix shellcheck directive format in update-repo.yml for actionlint compatibility

Closes #24

## Test plan

- [x] `make lint` passes locally (includes shell, JS, and actions)
- [x] `make lint-actions` runs actionlint successfully
- [ ] CI workflow passes with new actionlint step

🤖 Generated with [Claude Code](https://claude.com/claude-code)