### PR TITLE
Add repositories input for GitHub App token generation

### DIFF
--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: apt
 
       - name: Create PR with changes
         env:


### PR DESCRIPTION
## Summary
- Adds `repositories: apt` input to the `create-github-app-token` action to explicitly scope the generated token to this repository

## Test plan
- [x] Verify the update workflow runs successfully with the scoped token

🤖 Generated with [Claude Code](https://claude.com/claude-code)