### PR TITLE
Refactor GitHub App token to use dynamic repository name

### DIFF
--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          repositories: apt
+          repositories: ${{ github.event.repository.name }}
 
       - name: Create PR with changes
         env:


### PR DESCRIPTION
## Summary

- Updates the `repositories` input for GitHub App token generation to use `${{ github.event.repository.name }}` instead of hardcoded `apt`
- Makes the workflow more portable if the repository is renamed or forked

## Test plan

- [x] Trigger the update-repo workflow and verify the GitHub App token is generated correctly
- [x] Verify PR creation still works as expected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)