### PR TITLE
Add ci-tools package to apt repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Apt repository for Knight Owl packages, hosted on Cloudflare Pages with binaries
 
 ## Available Packages
 
+- [**ci-tools**](https://github.com/knight-owl-dev/devops) — CI/CD utilities
 - [**keystone-cli**](https://github.com/knight-owl-dev/keystone-cli) — Command-line interface for Keystone
 
 ## Installation

--- a/functions/pool/main/c/ci-tools/[[path]].js
+++ b/functions/pool/main/c/ci-tools/[[path]].js
@@ -1,0 +1,32 @@
+/**
+ * Cloudflare Pages Function to redirect .deb package requests to GitHub Releases.
+ *
+ * Parses the version from the filename and redirects to the versioned release URL.
+ *
+ * Example:
+ *   Request:  /pool/main/c/ci-tools/ci-tools_1.0.8_amd64.deb
+ *   Redirect: https://github.com/knight-owl-dev/devops/releases/download/v1.0.8/ci-tools_1.0.8_amd64.deb
+ */
+export function onRequest(context) {
+  const url = new URL(context.request.url);
+  const path = url.pathname;
+
+  // Extract filename from path
+  // Path: /pool/main/c/ci-tools/ci-tools_1.0.8_amd64.deb
+  const filename = path.split('/').pop();
+
+  // Parse version from filename: ci-tools_{version}_{arch}.deb
+  // Version must be semver format: X.Y.Z or X.Y.Z-prerelease (e.g., 1.0.8, 2.0.0-beta.1)
+  const match = filename.match(
+    /^ci-tools_(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?)_(amd64|arm64)\.deb$/,
+  );
+
+  if (!match) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const version = match[1];
+  const redirectUrl = `https://github.com/knight-owl-dev/devops/releases/download/v${version}/${filename}`;
+
+  return Response.redirect(redirectUrl, 302);
+}

--- a/packages.yml
+++ b/packages.yml
@@ -17,3 +17,10 @@ packages:
       - amd64
       - arm64
     verify: keystone-cli info
+
+  - name: ci-tools
+    repo: knight-owl-dev/devops
+    architectures:
+      - amd64
+      - arm64
+    verify: validate-action-pins --version


### PR DESCRIPTION
## Summary

- Add `ci-tools` package entry to `packages.yml` (repo: `knight-owl-dev/devops`, amd64/arm64)
- Create Cloudflare redirect function at `functions/pool/main/c/ci-tools/[[path]].js`
- Add `ci-tools` to the Available Packages list in README

Closes #39

## Test plan

- [ ] CI passes (lint, validation)
- [ ] After merge, trigger Update Repository workflow with `ci-tools:1.0.8` to generate signed metadata
- [ ] Verify `apt-get install ci-tools` works on a Debian/Ubuntu system

🤖 Generated with [Claude Code](https://claude.com/claude-code)