### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Lint
         run: make lint
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout apt repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -33,7 +33,7 @@ jobs:
       # infrastructure before git push (avoids intermittent 403 errors)
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ lint-actions: ## Check GitHub Actions workflows (actionlint)
 	@echo "Checking GitHub Actions workflows..."
 	@actionlint .github/workflows/*.yml
 	@echo "OK"
+	@echo "Validating action pins..."
+	@validate-action-pins .github/workflows/*.yml
+	@echo "OK"
 
 lint-md: ## Check Markdown files (markdownlint)
 	@echo "Checking Markdown..."


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references to full commit SHAs with semver comments, per supply-chain security policy
- Add `validate-action-pins` check to `make lint-actions` to catch unpinned actions going forward

Closes #55

### Pins applied

- `actions/checkout@v6` → `@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
- `actions/create-github-app-token@v3` → `@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1`

## Test plan

- [x] `make lint-actions` passes (actionlint + validate-action-pins)
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)